### PR TITLE
14822: Github dependabot security alters

### DIFF
--- a/GraphQLAdaptor/GridClient/package.json
+++ b/GraphQLAdaptor/GridClient/package.json
@@ -29,7 +29,7 @@
     "typescript": "*",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.0",
-    "webpack-dev-server": "^4.11.1",
+    "webpack-dev-server": "^5.2.1",
     "webpack-stream": "^7.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
### Bug description

Github dependabot security alters

### Root cause

The script error occurred because 

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.

- [ ] Guidelines/documents are not followed

- Common guidelines / Core team guideline

- Specification document

- Requirement document

- [x] Guidelines/documents are not given

- Common guidelines / Core team guideline

- Specification document

- Requirement document

### Reason:

Guidelines/documents are not given - Requirement document

### Action taken:

NA

### Related areas:

Grid's CDN link

### Is it a breaking issue?

No

### Solution description

The issue has been fully resolved by set the MultiSelect module

### Output screenshots

NA

### Areas affected and ensured

grid.ts

Ensured the following cases:

 -  Confirmed that 
 
### Additional checklist

This may vary for different teams or products. Check with your scrum masters.

- Did you run the automation against your fix? - Yes

- Is there any API name change? - No

- Is there any existing behavior change of other features due to this code change? - No

- Does your new code introduce new warnings or binding errors? - No

- Does your code pass all FxCop and StyleCop rules? a- No

- Did you record this case in the unit test or UI test? - Yes